### PR TITLE
Added reload endpoint w/ token

### DIFF
--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -14,15 +14,15 @@ import (
 
 // ServiceSetConfig provides configuration options for a ServiceSet
 type ServiceSetConfig struct {
-	EnableServiceList        bool
-	EnableTileJSON           bool
-	EnablePreview            bool
-	EnableArcGIS             bool
-	EnableReloadEndpoint     bool
-	ReloadToken              string
+	EnableServiceList    bool
+	EnableTileJSON       bool
+	EnablePreview        bool
+	EnableArcGIS         bool
+	EnableReloadEndpoint bool
+	ReloadToken          string
 
-	RootURL           *url.URL
-	ErrorWriter       io.Writer
+	RootURL     *url.URL
+	ErrorWriter io.Writer
 }
 
 // ServiceSet is a group of tilesets plus configuration options.
@@ -30,16 +30,16 @@ type ServiceSetConfig struct {
 type ServiceSet struct {
 	tilesets map[string]*Tileset
 
-	enableServiceList        bool
-	enableTileJSON           bool
-	enablePreview            bool
-	enableArcGIS             bool
-	enableReloadEndpoint     bool
-	reloadToken              string
+	enableServiceList    bool
+	enableTileJSON       bool
+	enablePreview        bool
+	enableArcGIS         bool
+	enableReloadEndpoint bool
+	reloadToken          string
 
-	domain            string
-	rootURL           *url.URL
-	errorWriter       io.Writer
+	domain      string
+	rootURL     *url.URL
+	errorWriter io.Writer
 }
 
 // New returns a new ServiceSet.
@@ -51,16 +51,16 @@ func New(cfg *ServiceSetConfig) (*ServiceSet, error) {
 	}
 
 	s := &ServiceSet{
-		tilesets:          make(map[string]*Tileset),
-		enableServiceList:        cfg.EnableServiceList,
-		enableTileJSON:           cfg.EnableTileJSON,
-		enablePreview:            cfg.EnablePreview,
-		enableArcGIS:             cfg.EnableArcGIS,
-		enableReloadEndpoint:     cfg.EnableReloadEndpoint,
-		reloadToken:              cfg.ReloadToken,
+		tilesets:             make(map[string]*Tileset),
+		enableServiceList:    cfg.EnableServiceList,
+		enableTileJSON:       cfg.EnableTileJSON,
+		enablePreview:        cfg.EnablePreview,
+		enableArcGIS:         cfg.EnableArcGIS,
+		enableReloadEndpoint: cfg.EnableReloadEndpoint,
+		reloadToken:          cfg.ReloadToken,
 
-		rootURL:           cfg.RootURL,
-		errorWriter:       cfg.ErrorWriter,
+		rootURL:     cfg.RootURL,
+		errorWriter: cfg.ErrorWriter,
 	}
 
 	return s, nil
@@ -178,7 +178,7 @@ func (s *ServiceSet) logError(format string, args ...interface{}) {
 
 // reloadEndpointHandler
 func (s *ServiceSet) reloadEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	token := r.URL.Query().Get("token")
+	token, err := r.URL.Query().Get("token")
 	if s.enableReloadEndpoint && token == s.reloadToken {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {

--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -18,7 +18,6 @@ type ServiceSetConfig struct {
 	EnableTileJSON       bool
 	EnablePreview        bool
 	EnableArcGIS         bool
-	EnableReloadEndpoint bool
 	ReloadToken          string
 
 	RootURL     *url.URL
@@ -34,7 +33,6 @@ type ServiceSet struct {
 	enableTileJSON       bool
 	enablePreview        bool
 	enableArcGIS         bool
-	enableReloadEndpoint bool
 	reloadToken          string
 
 	domain      string
@@ -56,7 +54,6 @@ func New(cfg *ServiceSetConfig) (*ServiceSet, error) {
 		enableTileJSON:       cfg.EnableTileJSON,
 		enablePreview:        cfg.EnablePreview,
 		enableArcGIS:         cfg.EnableArcGIS,
-		enableReloadEndpoint: cfg.EnableReloadEndpoint,
 		reloadToken:          cfg.ReloadToken,
 
 		rootURL:     cfg.RootURL,
@@ -178,11 +175,11 @@ func (s *ServiceSet) logError(format string, args ...interface{}) {
 
 // reloadEndpointHandler
 func (s *ServiceSet) reloadEndpointHandler(w http.ResponseWriter, r *http.Request) {
-	token, err := r.URL.Query().Get("token")
-	if s.enableReloadEndpoint && token == s.reloadToken {
+	token := r.URL.Query().Get("token")
+	if token == s.reloadToken {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
-			http.NotFound(w, r)
+			s.logError("Error rendering response during reload: %v", err)
 			return
 		}
 		syscall.Kill(syscall.Getpid(), syscall.SIGHUP)

--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -14,12 +14,13 @@ import (
 
 // ServiceSetConfig provides configuration options for a ServiceSet
 type ServiceSetConfig struct {
-	EnableServiceList bool
-	EnableTileJSON    bool
-	EnablePreview     bool
-	EnableArcGIS      bool
-	EnableRefresh     bool
-	RefreshToken      string
+	EnableServiceList        bool
+	EnableTileJSON           bool
+	EnablePreview            bool
+	EnableArcGIS             bool
+	EnableReloadEndpoint     bool
+	ReloadToken              string
+
 	RootURL           *url.URL
 	ErrorWriter       io.Writer
 }
@@ -29,12 +30,13 @@ type ServiceSetConfig struct {
 type ServiceSet struct {
 	tilesets map[string]*Tileset
 
-	enableServiceList bool
-	enableTileJSON    bool
-	enablePreview     bool
-	enableArcGIS      bool
-	enableRefresh     bool
-	refreshToken      string
+	enableServiceList        bool
+	enableTileJSON           bool
+	enablePreview            bool
+	enableArcGIS             bool
+	enableReloadEndpoint     bool
+	reloadToken              string
+
 	domain            string
 	rootURL           *url.URL
 	errorWriter       io.Writer
@@ -50,12 +52,13 @@ func New(cfg *ServiceSetConfig) (*ServiceSet, error) {
 
 	s := &ServiceSet{
 		tilesets:          make(map[string]*Tileset),
-		enableServiceList: cfg.EnableServiceList,
-		enableTileJSON:    cfg.EnableTileJSON,
-		enablePreview:     cfg.EnablePreview,
-		enableArcGIS:      cfg.EnableArcGIS,
-		enableRefresh:     cfg.EnableRefresh,
-		refreshToken:      cfg.RefreshToken,
+		enableServiceList:        cfg.EnableServiceList,
+		enableTileJSON:           cfg.EnableTileJSON,
+		enablePreview:            cfg.EnablePreview,
+		enableArcGIS:             cfg.EnableArcGIS,
+		enableReloadEndpoint:     cfg.EnableReloadEndpoint,
+		reloadToken:              cfg.ReloadToken,
+
 		rootURL:           cfg.RootURL,
 		errorWriter:       cfg.ErrorWriter,
 	}
@@ -173,10 +176,10 @@ func (s *ServiceSet) logError(format string, args ...interface{}) {
 	}
 }
 
-// refreshHandler
-func (s *ServiceSet) refreshHandler(w http.ResponseWriter, r *http.Request) {
+// reloadEndpointHandler
+func (s *ServiceSet) reloadEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
-	if s.enableRefresh && token == s.refreshToken {
+	if s.enableReloadEndpoint && token == s.reloadToken {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
 			http.NotFound(w, r)
@@ -303,6 +306,6 @@ func (s *ServiceSet) Handler() http.Handler {
 		m.Handle(ArcGISRoot, http.NotFoundHandler())
 	}
 
-	m.HandleFunc("/refresh", s.refreshHandler)
+	m.HandleFunc("/reload", s.reloadEndpointHandler)
 	return m
 }

--- a/main.go
+++ b/main.go
@@ -74,7 +74,6 @@ var (
 	redirect             bool
 	enableReloadSignal   bool
 	enableReloadFSWatch  bool
-	enableReloadEndpoint bool
 	reloadToken          string
 	generateIDs          bool
 	enableArcGIS         bool
@@ -97,7 +96,6 @@ func init() {
 	flags.BoolVarP(&autotls, "tls", "t", false, "Auto TLS via Let's Encrypt")
 	flags.BoolVarP(&redirect, "redirect", "r", false, "Redirect HTTP to HTTPS")
 
-	flags.BoolVar(&enableReloadEndpoint, "enable-reload-endpoint", false, "Enable reload endpoint, depends on enable-reload-signal")
 	flags.StringVar(&reloadToken, "reload-endpoint-token", "", "Token for reload endpoint")
 	flags.BoolVarP(&enableArcGIS, "enable-arcgis", "", false, "Enable ArcGIS Mapserver endpoints")
 	flags.BoolVarP(&enableReloadFSWatch, "enable-fs-watch", "", false, "Enable reloading of tilesets by watching filesystem")
@@ -234,11 +232,8 @@ func serve() {
 		disablePreview = true
 	}
 
-	if enableReloadEndpoint && !enableReloadSignal {
+	if !enableReloadSignal && reloadToken != "" {
 		log.Fatalln("Must enable the reload signal for the endpoint")
-	}
-	if enableReloadEndpoint && reloadToken == "" {
-		log.Fatalln("Must specify a reload-token")
 	}
 
 	if !strings.HasPrefix(rootURLStr, "/") {
@@ -292,7 +287,6 @@ func serve() {
 		EnableTileJSON:       !disableTileJSON,
 		EnablePreview:        !disablePreview,
 		EnableArcGIS:         enableArcGIS,
-		EnableReloadEndpoint: enableReloadEndpoint,
 		ReloadToken:          reloadToken,
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -61,27 +61,27 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	port                int
-	tilePath            string
-	certificate         string
-	privateKey          string
-	rootURLStr          string
-	domain              string
-	secretKey           string
-	sentryDSN           string
-	verbose             bool
-	autotls             bool
-	redirect            bool
-	enableReloadSignal  bool
-	enableReloadFSWatch bool
-	enableReloadEndpoint       bool
-	reloadToken        string
-	generateIDs         bool
-	enableArcGIS        bool
-	disablePreview      bool
-	disableTileJSON     bool
-	disableServiceList  bool
-	tilesOnly           bool
+	port                 int
+	tilePath             string
+	certificate          string
+	privateKey           string
+	rootURLStr           string
+	domain               string
+	secretKey            string
+	sentryDSN            string
+	verbose              bool
+	autotls              bool
+	redirect             bool
+	enableReloadSignal   bool
+	enableReloadFSWatch  bool
+	enableReloadEndpoint bool
+	reloadToken          string
+	generateIDs          bool
+	enableArcGIS         bool
+	disablePreview       bool
+	disableTileJSON      bool
+	disableServiceList   bool
+	tilesOnly            bool
 )
 
 func init() {
@@ -286,14 +286,14 @@ func serve() {
 	}
 
 	svcSet, err := handlers.New(&handlers.ServiceSetConfig{
-		RootURL:           rootURL,
-		ErrorWriter:       &errorLogger{log: log.New()},
-		EnableServiceList: !disableServiceList,
-		EnableTileJSON:    !disableTileJSON,
-		EnablePreview:     !disablePreview,
-		EnableArcGIS:      enableArcGIS,
-		EnableReloadEndpoint:     enableReloadEndpoint,
-		ReloadToken:      reloadToken,
+		RootURL:              rootURL,
+		ErrorWriter:          &errorLogger{log: log.New()},
+		EnableServiceList:    !disableServiceList,
+		EnableTileJSON:       !disableTileJSON,
+		EnablePreview:        !disablePreview,
+		EnableArcGIS:         enableArcGIS,
+		EnableReloadEndpoint: enableReloadEndpoint,
+		ReloadToken:          reloadToken,
 	})
 	if err != nil {
 		log.Fatalln("Could not construct ServiceSet")

--- a/main.go
+++ b/main.go
@@ -61,26 +61,26 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	port                 int
-	tilePath             string
-	certificate          string
-	privateKey           string
-	rootURLStr           string
-	domain               string
-	secretKey            string
-	sentryDSN            string
-	verbose              bool
-	autotls              bool
-	redirect             bool
-	enableReloadSignal   bool
-	enableReloadFSWatch  bool
-	reloadToken          string
-	generateIDs          bool
-	enableArcGIS         bool
-	disablePreview       bool
-	disableTileJSON      bool
-	disableServiceList   bool
-	tilesOnly            bool
+	port                int
+	tilePath            string
+	certificate         string
+	privateKey          string
+	rootURLStr          string
+	domain              string
+	secretKey           string
+	sentryDSN           string
+	verbose             bool
+	autotls             bool
+	redirect            bool
+	enableReloadSignal  bool
+	enableReloadFSWatch bool
+	reloadToken         string
+	generateIDs         bool
+	enableArcGIS        bool
+	disablePreview      bool
+	disableTileJSON     bool
+	disableServiceList  bool
+	tilesOnly           bool
 )
 
 func init() {
@@ -96,7 +96,7 @@ func init() {
 	flags.BoolVarP(&autotls, "tls", "t", false, "Auto TLS via Let's Encrypt")
 	flags.BoolVarP(&redirect, "redirect", "r", false, "Redirect HTTP to HTTPS")
 
-	flags.StringVar(&reloadToken, "reload-endpoint-token", "", "Token for reload endpoint")
+	flags.StringVar(&reloadToken, "reload-endpoint-token", "", "Sets a tokenized for reload endpoint")
 	flags.BoolVarP(&enableArcGIS, "enable-arcgis", "", false, "Enable ArcGIS Mapserver endpoints")
 	flags.BoolVarP(&enableReloadFSWatch, "enable-fs-watch", "", false, "Enable reloading of tilesets by watching filesystem")
 	flags.BoolVarP(&enableReloadSignal, "enable-reload-signal", "", false, "Enable graceful reload using HUP signal to the server process")
@@ -281,13 +281,14 @@ func serve() {
 	}
 
 	svcSet, err := handlers.New(&handlers.ServiceSetConfig{
-		RootURL:              rootURL,
-		ErrorWriter:          &errorLogger{log: log.New()},
-		EnableServiceList:    !disableServiceList,
-		EnableTileJSON:       !disableTileJSON,
-		EnablePreview:        !disablePreview,
-		EnableArcGIS:         enableArcGIS,
-		ReloadToken:          reloadToken,
+		RootURL:            rootURL,
+		ErrorWriter:        &errorLogger{log: log.New()},
+		EnableServiceList:  !disableServiceList,
+		EnableTileJSON:     !disableTileJSON,
+		EnablePreview:      !disablePreview,
+		EnableArcGIS:       enableArcGIS,
+		EnableReloadSignal: enableReloadSignal,
+		ReloadToken:        reloadToken,
 	})
 	if err != nil {
 		log.Fatalln("Could not construct ServiceSet")

--- a/main.go
+++ b/main.go
@@ -74,8 +74,8 @@ var (
 	redirect            bool
 	enableReloadSignal  bool
 	enableReloadFSWatch bool
-	enableRefresh       bool
-	refreshToken        string
+	enableReloadEndpoint       bool
+	reloadToken        string
 	generateIDs         bool
 	enableArcGIS        bool
 	disablePreview      bool
@@ -97,8 +97,8 @@ func init() {
 	flags.BoolVarP(&autotls, "tls", "t", false, "Auto TLS via Let's Encrypt")
 	flags.BoolVarP(&redirect, "redirect", "r", false, "Redirect HTTP to HTTPS")
 
-	flags.BoolVar(&enableRefresh, "enable-refresh", false, "Enable refresh endpoints")
-	flags.StringVar(&refreshToken, "refresh-token", "", "Enable refresh endpoints")
+	flags.BoolVar(&enableReloadEndpoint, "enable-reload-endpoint", false, "Enable reload endpoint, depends on enable-reload-signal")
+	flags.StringVar(&reloadToken, "reload-endpoint-token", "", "Token for reload endpoint")
 	flags.BoolVarP(&enableArcGIS, "enable-arcgis", "", false, "Enable ArcGIS Mapserver endpoints")
 	flags.BoolVarP(&enableReloadFSWatch, "enable-fs-watch", "", false, "Enable reloading of tilesets by watching filesystem")
 	flags.BoolVarP(&enableReloadSignal, "enable-reload-signal", "", false, "Enable graceful reload using HUP signal to the server process")
@@ -234,8 +234,11 @@ func serve() {
 		disablePreview = true
 	}
 
-	if enableRefresh && refreshToken == "" {
-		log.Fatalln("Must specify a refresh-token")
+	if enableReloadEndpoint && !enableReloadSignal {
+		log.Fatalln("Must enable the reload signal for the endpoint")
+	}
+	if enableReloadEndpoint && reloadToken == "" {
+		log.Fatalln("Must specify a reload-token")
 	}
 
 	if !strings.HasPrefix(rootURLStr, "/") {
@@ -289,8 +292,8 @@ func serve() {
 		EnableTileJSON:    !disableTileJSON,
 		EnablePreview:     !disablePreview,
 		EnableArcGIS:      enableArcGIS,
-		EnableRefresh:     enableRefresh,
-		RefreshToken:      refreshToken,
+		EnableReloadEndpoint:     enableReloadEndpoint,
+		ReloadToken:      reloadToken,
 	})
 	if err != nil {
 		log.Fatalln("Could not construct ServiceSet")


### PR DESCRIPTION
- Add /refresh?token=specified_token endpoint that sends `SIGHUP`
- Enables a reloading alternative for shared NFS drives that can't take advantage of `inotify` kernel hooks
- Example command: `./mbtileserver -d ~/mbtiles --enable-fs-watch --enable-reload-signal --enable-reload-endpoint --reload-endpoint-token c830f81a`