### PR TITLE
Add load/unload endpoints for tilesets

### DIFF
--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -193,7 +193,6 @@ func (s *ServiceSet) loadEndpointHandler(w http.ResponseWriter, r *http.Request)
 			s.logError("Error rendering response during reload: %v", err)
 			return
 		}
-		// syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
 		id, err := s.generateID(path, s.baseDir)
 		if err != nil {
 			s.logError("Could not create ID for tileset %q\n%v", path, err)
@@ -222,7 +221,6 @@ func (s *ServiceSet) unloadEndpointHandler(w http.ResponseWriter, r *http.Reques
 			s.logError("Error rendering response during reload: %v", err)
 			return
 		}
-		// syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
 		id, err := s.generateID(path, s.baseDir)
 		if err != nil {
 			s.logError("Could not create ID for tileset %q\n%v", path, err)

--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"syscall"
 )
 
 // ServiceSetConfig provides configuration options for a ServiceSet
@@ -19,10 +18,12 @@ type ServiceSetConfig struct {
 	EnablePreview      bool
 	EnableArcGIS       bool
 	EnableReloadSignal bool
-	ReloadToken        string
+	AuthToken        string
 
 	RootURL     *url.URL
 	ErrorWriter io.Writer
+	GenerateID  func(string, string) (string, error)
+	BaseDir		string
 }
 
 // ServiceSet is a group of tilesets plus configuration options.
@@ -35,11 +36,13 @@ type ServiceSet struct {
 	enablePreview      bool
 	enableArcGIS       bool
 	enableReloadSignal bool
-	reloadToken        string
+	authToken        string
 
 	domain      string
 	rootURL     *url.URL
 	errorWriter io.Writer
+	generateID  func(string, string) (string, error)
+	baseDir		string
 }
 
 // New returns a new ServiceSet.
@@ -57,10 +60,12 @@ func New(cfg *ServiceSetConfig) (*ServiceSet, error) {
 		enablePreview:      cfg.EnablePreview,
 		enableArcGIS:       cfg.EnableArcGIS,
 		enableReloadSignal: cfg.EnableReloadSignal,
-		reloadToken:        cfg.ReloadToken,
+		authToken:        cfg.AuthToken,
 
 		rootURL:     cfg.RootURL,
 		errorWriter: cfg.ErrorWriter,
+		generateID:  cfg.GenerateID,
+		baseDir:	 cfg.BaseDir,
 	}
 
 	return s, nil
@@ -176,19 +181,59 @@ func (s *ServiceSet) logError(format string, args ...interface{}) {
 	}
 }
 
-// reloadEndpointHandler
-func (s *ServiceSet) reloadEndpointHandler(w http.ResponseWriter, r *http.Request) {
+func (s *ServiceSet) loadEndpointHandler(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
-	if !s.enableReloadSignal || s.reloadToken == "" {
+	path := r.URL.Query().Get("path")
+	if s.authToken == "" || path == "" {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
-	} else if s.enableReloadSignal && token == s.reloadToken {
+	} else if token == s.authToken {
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
 			s.logError("Error rendering response during reload: %v", err)
 			return
 		}
-		syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		// syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		id, err := s.generateID(path, s.baseDir)
+		if err != nil {
+			s.logError("Could not create ID for tileset %q\n%v", path, err)
+			return
+		}
+		err = s.AddTileset(path, id)
+		if err != nil {
+			s.logError("Could not add tileset for %q with ID %q\n%v", path, id, err)
+		} else {
+			log.Printf("Updated tileset %q with ID %q\n", path, id)
+		}
+		return
+	}
+	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+}
+
+func (s *ServiceSet) unloadEndpointHandler(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	path := r.URL.Query().Get("path")
+	if s.authToken == "" || path == "" {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	} else if token == s.authToken {
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			s.logError("Error rendering response during reload: %v", err)
+			return
+		}
+		// syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+		id, err := s.generateID(path, s.baseDir)
+		if err != nil {
+			s.logError("Could not create ID for tileset %q\n%v", path, err)
+			return
+		}
+		err = s.RemoveTileset(id)
+		if err != nil {
+			s.logError("Could not remove tileset for %q with ID %q\n%v", path, id, err)
+		} else {
+			log.Printf("Removed tileset %q with ID %q\n", path, id)
+		}
 		return
 	}
 	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
@@ -308,7 +353,8 @@ func (s *ServiceSet) Handler() http.Handler {
 		m.Handle(ArcGISRoot, http.NotFoundHandler())
 	}
 
-	m.HandleFunc("/reload", s.reloadEndpointHandler)
+	m.HandleFunc("/load", s.loadEndpointHandler)
+	m.HandleFunc("/unload", s.unloadEndpointHandler)
 	return m
 }
 

--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -23,7 +23,7 @@ type ServiceSetConfig struct {
 	RootURL     *url.URL
 	ErrorWriter io.Writer
 	GenerateID  func(string, string) (string, error)
-	BaseDir		string
+	BaseDir     string
 }
 
 // ServiceSet is a group of tilesets plus configuration options.
@@ -42,7 +42,7 @@ type ServiceSet struct {
 	rootURL     *url.URL
 	errorWriter io.Writer
 	generateID  func(string, string) (string, error)
-	baseDir		string
+	baseDir     string
 }
 
 // New returns a new ServiceSet.
@@ -60,12 +60,12 @@ func New(cfg *ServiceSetConfig) (*ServiceSet, error) {
 		enablePreview:      cfg.EnablePreview,
 		enableArcGIS:       cfg.EnableArcGIS,
 		enableReloadSignal: cfg.EnableReloadSignal,
-		authToken:        	cfg.AuthToken,
+		authToken:          cfg.AuthToken,
 
 		rootURL:     cfg.RootURL,
 		errorWriter: cfg.ErrorWriter,
 		generateID:  cfg.GenerateID,
-		baseDir:	 cfg.BaseDir,
+		baseDir:     cfg.BaseDir,
 	}
 
 	return s, nil

--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -18,7 +18,7 @@ type ServiceSetConfig struct {
 	EnablePreview      bool
 	EnableArcGIS       bool
 	EnableReloadSignal bool
-	AuthToken        string
+	AuthToken          string
 
 	RootURL     *url.URL
 	ErrorWriter io.Writer
@@ -36,7 +36,7 @@ type ServiceSet struct {
 	enablePreview      bool
 	enableArcGIS       bool
 	enableReloadSignal bool
-	authToken        string
+	authToken          string
 
 	domain      string
 	rootURL     *url.URL
@@ -60,7 +60,7 @@ func New(cfg *ServiceSetConfig) (*ServiceSet, error) {
 		enablePreview:      cfg.EnablePreview,
 		enableArcGIS:       cfg.EnableArcGIS,
 		enableReloadSignal: cfg.EnableReloadSignal,
-		authToken:        cfg.AuthToken,
+		authToken:        	cfg.AuthToken,
 
 		rootURL:     cfg.RootURL,
 		errorWriter: cfg.ErrorWriter,

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ var (
 	redirect            bool
 	enableReloadSignal  bool
 	enableReloadFSWatch bool
-	authToken         string
+	authToken         	string
 	generateIDs         bool
 	enableArcGIS        bool
 	disablePreview      bool
@@ -288,7 +288,7 @@ func serve() {
 		EnablePreview:      !disablePreview,
 		EnableArcGIS:       enableArcGIS,
 		EnableReloadSignal: enableReloadSignal,
-		AuthToken:        authToken,
+		AuthToken:        	authToken,
 		GenerateID:			generateID,
 		BaseDir:			tilePath,
 	})

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ var (
 	redirect            bool
 	enableReloadSignal  bool
 	enableReloadFSWatch bool
-	authToken         	string
+	authToken           string
 	generateIDs         bool
 	enableArcGIS        bool
 	disablePreview      bool
@@ -290,7 +290,7 @@ func serve() {
 		EnableReloadSignal: enableReloadSignal,
 		AuthToken:        	authToken,
 		GenerateID:			generateID,
-		BaseDir:			tilePath,
+		BaseDir:            tilePath,
 	})
 	if err != nil {
 		log.Fatalln("Could not construct ServiceSet")

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ var (
 	redirect            bool
 	enableReloadSignal  bool
 	enableReloadFSWatch bool
-	reloadToken         string
+	authToken         string
 	generateIDs         bool
 	enableArcGIS        bool
 	disablePreview      bool
@@ -96,7 +96,7 @@ func init() {
 	flags.BoolVarP(&autotls, "tls", "t", false, "Auto TLS via Let's Encrypt")
 	flags.BoolVarP(&redirect, "redirect", "r", false, "Redirect HTTP to HTTPS")
 
-	flags.StringVar(&reloadToken, "reload-endpoint-token", "", "Sets a tokenized for reload endpoint")
+	flags.StringVar(&authToken, "auth-token", "", "Sets a tokenized for reload endpoint")
 	flags.BoolVarP(&enableArcGIS, "enable-arcgis", "", false, "Enable ArcGIS Mapserver endpoints")
 	flags.BoolVarP(&enableReloadFSWatch, "enable-fs-watch", "", false, "Enable reloading of tilesets by watching filesystem")
 	flags.BoolVarP(&enableReloadSignal, "enable-reload-signal", "", false, "Enable graceful reload using HUP signal to the server process")
@@ -232,8 +232,8 @@ func serve() {
 		disablePreview = true
 	}
 
-	if !enableReloadSignal && reloadToken != "" {
-		log.Fatalln("Must enable the reload signal for the endpoint")
+	if authToken == "" {
+		log.Fatalln("Must provide an auth token")
 	}
 
 	if !strings.HasPrefix(rootURLStr, "/") {
@@ -288,7 +288,9 @@ func serve() {
 		EnablePreview:      !disablePreview,
 		EnableArcGIS:       enableArcGIS,
 		EnableReloadSignal: enableReloadSignal,
-		ReloadToken:        reloadToken,
+		AuthToken:        authToken,
+		GenerateID:			generateID,
+		BaseDir:			tilePath,
 	})
 	if err != nil {
 		log.Fatalln("Could not construct ServiceSet")


### PR DESCRIPTION
- Added an endpoint for loading a tileset by path
- Added an endpoint for removing a tileset by path
- Removed kill signal reload endpoint

Notes:

- This is a decidedly easier path than re-writing file scanning to use directory scans (we can't leverage the current implementation because it depends on `inotify`). Being new to golang, I thought maybe just best to do what pushes us forward rather than work on a decidedly more complicated task
- Must be merged with: https://github.com/felt/data-library/pull/406