### PR TITLE
Temporarily enable mutex and block profiler for tile serving

### DIFF
--- a/main.go
+++ b/main.go
@@ -365,7 +365,7 @@ func serve() {
 			profiler.CPUProfile,
 			profiler.HeapProfile,
 			profiler.MutexProfile,
-			profiler.BlockProfile
+			profiler.BlockProfile,
 		),
 	)
 

--- a/main.go
+++ b/main.go
@@ -364,6 +364,8 @@ func serve() {
 		profiler.WithProfileTypes(
 			profiler.CPUProfile,
 			profiler.HeapProfile,
+			profiler.MutexProfile,
+			profiler.BlockProfile
 		),
 	)
 


### PR DESCRIPTION
I was looking at this issue https://github.com/felt/data-library/issues/443 and commented some observations of how the full request time isn't captured in the cpu and heap profiles. 

I want to enable BlockProfile and MutexProfile for a bit to see if that can capture anymore detail. Datadog also claims these may add overhead but golang docs claim these profilers don't add any real overhead so I'm interested to see which is true!

